### PR TITLE
Fixed no operand D[BWL] segfault

### DIFF
--- a/src/pseudos.c
+++ b/src/pseudos.c
@@ -106,6 +106,11 @@ Xdc(int modifier, char *label, char *mnemo, char *oper)
 {
 	char *s1,*s2;
 	
+	if ( !oper )
+	{	error("need an operand");
+		return 1;
+	}
+
 	while ( filter( oper, "?_,_?", &s1,&s2 ) )
 	{	oper=s2;
 		stocke(s1,modifier);


### PR DESCRIPTION
Fixed no operand D[BWL] segfault, now calls error and Xdc returns immediately.
Test:
```
* = $8000
DB
DW
DL
```
Originally a segfault on line 2, now an error is issued per each D[BWL].