### PR TITLE
Fix two faulting cases

### DIFF
--- a/src/operator.c
+++ b/src/operator.c
@@ -412,7 +412,10 @@ void opdiv(struct result* presult, struct result* parg)
   presult->flags |= parg->flags;
   checktype(presult, L_ABSOLUTE);
   checktype(parg, L_ABSOLUTE);
-  presult->value /= parg->value;
+  if (parg->value != 0)
+  {
+    presult->value /= parg->value;
+  }
 }
 
 void oprlist(struct result* presult, struct result* parg)

--- a/src/pseudos.c
+++ b/src/pseudos.c
@@ -213,6 +213,11 @@ int Xnam(int modifier, char* label, char* mnemo, char* oper)
 /*  ASC string  */
 int Xasc(int modifier, char* label, char* mnemo, char* oper)
 {
+
+  if (oper == NULL) {
+    error("Need an operand");
+  }
+
   register char* s;
   register char r;
   register char delimiter;


### PR DESCRIPTION
Specific test cases can cause the program to both divide by zero and dereference a null pointer. The proposed PR is a minimal viable patch.