### PR TITLE
(a) Allow optional colon after a label, (b) fix mc6801 jsr

### DIFF
--- a/crasm.1
+++ b/crasm.1
@@ -78,9 +78,11 @@ where the brackets delimit optional parts.
 .br
 .BI "" label " = " expression " [;" comment "]"
 .br
-.BI "[" label "] " mnemonic " " operand " [;" comment "]"
+.BI "[" label "[:]] " mnemonic " " operand " [;" comment "]"
 .br
-.BI "" label "[;" comment "]"
+.BI "" label ": [;" comment "]"
+.br
+.BI "" label " [;" comment "]"
 .PP
 Comments are introduced by a semicolon 
 .BR "" "(" ";" ")"
@@ -88,10 +90,16 @@ and extend to the end of the line.
 Labels are identifiers containing up to 36 alphanumeric 
 characters (including period and underscore). Labels
 cannot start with a digit.
-Crasm does not usually pays attention to the column position
-of the line components. The only exception is the case
+
+Crasm does not usually pays attention to the column position of the
+line components. Extra spaces are generously allowed between these
+components.  However, in the last template, the label must start in
+the first column of the line. The only exception is the case
 of a line containing only a label and possibly a comment.
 In that case the label must start in column zero.
+Just add a colon
+.BR "" "(" ":" ")"
+after the label to lift this restriction.
 .PP
 The format of the mnemonics and operands 
 field depends on the selected micro-processor.

--- a/crasm.html
+++ b/crasm.html
@@ -6,8 +6,6 @@ Cross assembler for 6800/6801/6803/6502/65C02/Z80.
 <font face=arial,helvetica>
 <a href="https://github.com/colinbourassa/crasm">Summary</a>
 &nbsp;
-<a href="https://github.com/colinbourassa/crasm/archive/master.zip">Download</a>
-&nbsp;
 <a href="https://github.com/colinbourassa/crasm/tree/master/test">Examples</a>
 </font>
 <HR>
@@ -73,7 +71,11 @@ where the brackets delimit optional parts.
 <BR>
 <B></B><I>label</I><B> = </B><I>expression</I><B> [;</B><I>comment</I><B>]</B>
 <BR>
-<B>[</B><I>label</I><B>] </B><I>mnemonic</I><B> </B><I>operand</I><B> [;</B><I>comment</I><B>]</B>
+<B>[</B><I>label</I><B>[:]] </B><I>mnemonic</I><B> </B><I>operand</I><B> [;</B><I>comment</I><B>]</B>
+<BR>
+<I>label</I><B>: [;</B><I>comment</I><B>]</B>
+<BR>
+<I>label</I><B> [;</B><I>comment</I><B>]</B>
 </DL>
 <P>
 Comments are introduced by a semicolon 
@@ -82,6 +84,17 @@ and extend to the end of the line.
 Labels are identifiers containing up to 36 alphanumeric 
 characters (including period and underscore). Labels
 cannot start with a digit.
+<P>
+Crasm does not usually pays attention to the column position of the
+line components. Extra spaces are generously allowed between these
+components.  However, in the last template, the label must start in
+the first column of the line. The only exception is the case
+of a line containing only a label and possibly a comment.
+In that case the label must start in column zero.
+Just add a colon
+<B></B>(<B>:</B>)
+after the label to lift this restriction.
+<P>
 The format of the mnemonics and operands 
 field depends on the selected micro-processor.
 A few mnemonics are valid for all processors
@@ -113,7 +126,7 @@ underscores
 <B></B>(<B>_</B>).
 Labels cannot start with a digit.  
 They are case insensitive.
-<P>
+
 Labels starting with a period
 <B></B>(<B>.</B>)
 are local labels whose scope is either limited
@@ -401,8 +414,9 @@ Invocations of the macro can specify a list of comma
 separated operands.  The character sequences 
 <B>\1</B>, <B>\2</B>, ... <B>\</B><I>N</I>
 in the macro definition are replaced by the supplied operands.
-The character sequence <B>\0</B> is replaced by the number
-of supplied operands.
+The character sequence <B>\#</B> is replaced by the number
+of supplied operands. The character sequence <B>\*</B>
+is replaced by the unparsed macro arguments.
 <P>
 </DD><DT>
 <B>EXITM</B>

--- a/src/cpu6800.c
+++ b/src/cpu6800.c
@@ -23,6 +23,8 @@
 
 #include "cpu.h"
 
+static int cpuflag = 0;
+
 /* relative branchs */
 static int branch(int code, char* label, char* mnemo, char* oper)
 {
@@ -173,6 +175,12 @@ static int standard2(int code, char* label, char* mnemo, char* oper)
   int value;
 
   add = findmode(oper, &value);
+
+  if (add == 0x10 && code == 0x8d && cpuflag == 0)
+  {
+    add = 0x30;  /* jsr does not support direct on mc6800 */
+  }
+
   codemode(code, add, value);
 
   if (add == 0) /* immediate -> error */
@@ -194,7 +202,7 @@ static int standard3(int code, char* label, char* mnemo, char* oper)
 
   if (add == 0x10)
   {
-    add = 0x30;  /* direct -> extended */
+    add = 0x30;  /* convert direct to extended */
   }
 
   codemode(code, add, value);
@@ -307,7 +315,7 @@ mnemo("adca",  standard, 0x89)
 mnemo("oraa",  standard, 0x8a)
 mnemo("adda",  standard, 0x8b)
 mnemo("cpx",   standard, 0x8c)
-mnemo("jsr",   standard3, 0x8d)
+mnemo("jsr",   standard2, 0x8d)
 mnemo("lds",   standard, 0x8e)
 mnemo("sts",   standard2, 0x8f)
 
@@ -348,6 +356,8 @@ endmnemos
 
 void init6800(int code)
 {
+  cpuflag = code;
+  
   setflag(F_ADDR16);  /* 16 bit address       */
   clrflag(F_LOHI);    /* MSB first            */
   clrflag(F_RELATIF); /* no translatable code */

--- a/src/crasm.c
+++ b/src/crasm.c
@@ -456,6 +456,17 @@ int asmline(char* s, int status)
     oper = NULL;
     mnemo = NULL;
     label = NULL;
+
+    if (filter(s, "?_:_?", &mnemo, &oper))
+    {
+      label = mnemo;
+      if (checklabel(label) == FALSE)
+      {
+        crasm_error("malformed label");
+      }
+      s = oper;
+    }
+
 start:
 
     if (filter(s, "? _?", &mnemo, &oper) && *mnemo && *oper)
@@ -487,7 +498,9 @@ start:
     if (linestartswithoutblanks && label == NULL && oper == NULL && mnemo != NULL)
     {
       label = mnemo;
-
+    }
+    if (label)
+    {
       if (status & 2)
       {
         herelabel(label);

--- a/src/macro.c
+++ b/src/macro.c
@@ -428,15 +428,15 @@ int Xmacro(int status, char* label, char* mnemo, char* oper)
     crasm_error("nested macro definition");
   }
 
-  if (status & 1)
-  {
-    outputline();
-  }
-
   if (status & 2)
   {
     lbl = deflabel(mname, 0, L_MACRO, 0);
     lbl->ptr = 0;
+  }
+
+  if (status & 1)
+  {
+    outputline();
   }
 
   jmp_buf_copy(errjmpsav, errorjump);


### PR DESCRIPTION
Since I am it.

This patch enables an optional colon after labels.

Doc:
```
SYNTAX
       Each line of the assembly program should follow one of the following templates, where
       the brackets delimit optional parts.

              [;comment]
              label = expression [;comment]
              [label[:]] mnemonic operand [;comment]
              label: [;comment]
              label [;comment]

       Comments are introduced by a semicolon (;) and extend to the end of the line.  Labels
       are identifiers containing up to 36 alphanumeric characters (including period and
       underscore). Labels cannot start with a digit.

       Crasm does not usually pays attention to the column position of the line components.
       Extra spaces are generously allowed between these components.  However, in the last
       template, the label must start in the first column of the line. The only exception is
       the case of a line containing only a label and possibly a comment.  In that case the
       label must start in column zero.  Just add a colon (:) after the label to lift this
       restriction.
```

I also updated (manually) the html file to match the man page. 
It was quite out of date.